### PR TITLE
drivers/can: switch from semaphore to mutex for CAN driver

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -96,10 +96,6 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-/* Semaphore helpers */
-
-static int            can_takesem(FAR sem_t *sem);
-
 /* Poll helpers */
 
 static void           can_pollnotify(FAR struct can_dev_s *dev,
@@ -153,21 +149,6 @@ static const struct file_operations g_canops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: can_takesem
- ****************************************************************************/
-
-static int can_takesem(FAR sem_t *sem)
-{
-  return nxsem_wait(sem);
-}
-
-/****************************************************************************
- * Name: can_givesem
- ****************************************************************************/
-
-#define can_givesem(sem) nxsem_post(sem)
 
 /****************************************************************************
  * Name: can_pollnotify
@@ -355,7 +336,7 @@ static void can_txready_work(FAR void *arg)
             {
               /* Yes.. Inform them that new xmit space is available */
 
-              can_givesem(&dev->cd_xmit.tx_sem);
+              nxsem_post(&dev->cd_xmit.tx_sem);
             }
         }
     }
@@ -396,7 +377,7 @@ static int can_open(FAR struct file *filep)
 
   /* If the port is the middle of closing, wait until the close is finished */
 
-  ret = can_takesem(&dev->cd_closesem);
+  ret = nxmutex_lock(&dev->cd_closelock);
   if (ret < 0)
     {
       return ret;
@@ -453,7 +434,7 @@ static int can_open(FAR struct file *filep)
     }
 
 errout:
-  can_givesem(&dev->cd_closesem);
+  nxmutex_unlock(&dev->cd_closelock);
   return ret;
 }
 
@@ -479,7 +460,7 @@ static int can_close(FAR struct file *filep)
   caninfo("ocount: %u\n", dev->cd_crefs);
 #endif
 
-  ret = can_takesem(&dev->cd_closesem);
+  ret = nxmutex_lock(&dev->cd_closelock);
   if (ret < 0)
     {
       return ret;
@@ -531,7 +512,7 @@ static int can_close(FAR struct file *filep)
   leave_critical_section(flags);
 
 errout:
-  can_givesem(&dev->cd_closesem);
+  nxmutex_unlock(&dev->cd_closelock);
   return ret;
 }
 
@@ -556,7 +537,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
   FAR struct can_dev_s     *dev = inode->i_private;
 #endif
 
-  caninfo("buflen: %d\n", buflen);
+  caninfo("buflen: %zu\n", buflen);
 
   /* The caller must provide enough memory to catch the smallest possible
    * message.  This is not a system error condition, but we won't permit
@@ -626,7 +607,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
         }
       else
         {
-          ret = can_takesem(&fifo->rx_sem);
+          ret = nxsem_wait(&fifo->rx_sem);
         }
 
       if (ret < 0)
@@ -679,7 +660,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
            * don't block.
            */
 
-          can_givesem(&fifo->rx_sem);
+          nxsem_post(&fifo->rx_sem);
         }
 
       /* Return the number of bytes that were read. */
@@ -793,7 +774,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
   int                      msglen;
   int                      ret   = 0;
 
-  caninfo("buflen: %d\n", buflen);
+  caninfo("buflen: %zu\n", buflen);
 
   /* Interrupts must disabled throughout the following */
 
@@ -859,7 +840,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
 
           DEBUGASSERT(dev->cd_ntxwaiters < 255);
           dev->cd_ntxwaiters++;
-          ret = can_takesem(&fifo->tx_sem);
+          ret = nxsem_wait(&fifo->tx_sem);
           dev->cd_ntxwaiters--;
           if (ret < 0)
             {
@@ -1088,7 +1069,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   /* Get exclusive access to the poll structures */
 
-  ret = can_takesem(&dev->cd_pollsem);
+  ret = nxmutex_lock(&dev->cd_polllock);
   if (ret < 0)
     {
       /* A signal received while waiting for access to the poll data
@@ -1141,7 +1122,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
       dev->cd_ntxwaiters++;
       do
         {
-          ret = can_takesem(&dev->cd_xmit.tx_sem);
+          ret = nxsem_wait(&dev->cd_xmit.tx_sem);
         }
       while (ret < 0);
       dev->cd_ntxwaiters--;
@@ -1157,7 +1138,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
           eventset |= fds->events & POLLOUT;
         }
 
-      can_givesem(&dev->cd_xmit.tx_sem);
+      nxsem_post(&dev->cd_xmit.tx_sem);
 
       /* Check whether there are messages in the RX FIFO. */
 
@@ -1165,7 +1146,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (ret < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           goto return_with_irqdisabled;
         }
       else if (sval > 0)
@@ -1208,7 +1189,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
     }
 
 errout:
-  can_givesem(&dev->cd_pollsem);
+  nxmutex_unlock(&dev->cd_polllock);
 
 return_with_irqdisabled:
   leave_critical_section(flags);
@@ -1245,8 +1226,8 @@ int can_register(FAR const char *path, FAR struct can_dev_s *dev)
 
   nxsem_init(&dev->cd_xmit.tx_sem, 0, 1);
   nxsem_set_protocol(&dev->cd_xmit.tx_sem, SEM_PRIO_NONE);
-  nxsem_init(&dev->cd_closesem,    0, 1);
-  nxsem_init(&dev->cd_pollsem,     0, 1);
+  nxmutex_init(&dev->cd_closelock);
+  nxmutex_init(&dev->cd_polllock);
 
   for (i = 0; i < CONFIG_CAN_NPENDINGRTR; i++)
     {
@@ -1355,7 +1336,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 
               /* Restart the waiting thread and mark the entry unused */
 
-              can_givesem(&wait->cr_sem);
+              nxsem_post(&wait->cr_sem);
             }
         }
     }
@@ -1406,7 +1387,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
           sval = 0;
           if (nxsem_get_value(&fifo->rx_sem, &sval) < 0)
             {
-              DEBUGASSERT(false);
+              DEBUGPANIC();
 #ifdef CONFIG_CAN_ERRORS
               /* Report unspecified error */
 
@@ -1422,7 +1403,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 
           if (sval <= 0)
             {
-              can_givesem(&fifo->rx_sem);
+              nxsem_post(&fifo->rx_sem);
             }
 
           errcode = OK;
@@ -1554,7 +1535,7 @@ int can_txdone(FAR struct can_dev_s *dev)
         {
           /* Yes.. Inform them that new xmit space is available */
 
-          ret = can_givesem(&dev->cd_xmit.tx_sem);
+          ret = nxsem_post(&dev->cd_xmit.tx_sem);
         }
       else
         {

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -36,7 +36,7 @@
 #include <nuttx/list.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
-#include <nuttx/semaphore.h>
+#include <nuttx/mutex.h>
 
 #ifdef CONFIG_CAN_TXREADY
 #  include <nuttx/wqueue.h>
@@ -563,7 +563,8 @@ struct can_ops_s
 
   /* All ioctl calls will be routed through this method */
 
-  CODE int (*co_ioctl)(FAR struct can_dev_s *dev, int cmd, unsigned long arg);
+  CODE int (*co_ioctl)(FAR struct can_dev_s *dev,
+                       int cmd, unsigned long arg);
 
   /* Send a remote request. Lower-half drivers should NOT implement this if
    * they support sending RTR messages with the regular send function
@@ -616,8 +617,8 @@ struct can_dev_s
   uint8_t              cd_error;         /* Flags to indicate internal device errors */
 #endif
   struct list_node     cd_readers;       /* List of readers */
-  sem_t                cd_closesem;      /* Locks out new opens while close is in progress */
-  sem_t                cd_pollsem;       /* Manages exclusive access to cd_fds[] */
+  mutex_t              cd_closelock;     /* Locks out new opens while close is in progress */
+  mutex_t              cd_polllock;      /* Manages exclusive access to cd_fds[] */
   struct can_txfifo_s  cd_xmit;          /* Describes transmit FIFO */
 #ifdef CONFIG_CAN_TXREADY
   struct work_s        cd_work;          /* Use to manage can_txready() work */


### PR DESCRIPTION
## Summary
switch from semaphore to mutex for CAN driver

## Impact
N/A

## Testing
None
