### PR TITLE
arm_assert: call board_crashdump() as first call in up_assert()

### DIFF
--- a/arch/arm/src/common/arm_assert.c
+++ b/arch/arm/src/common/arm_assert.c
@@ -512,6 +512,10 @@ static void arm_assert(void)
 
 void up_assert(const char *filename, int lineno)
 {
+#ifdef CONFIG_BOARD_CRASHDUMP
+  board_crashdump(up_getsp(), running_task(), filename, lineno);
+#endif
+
   board_autoled_on(LED_ASSERTION);
 
   /* Flush any buffered SYSLOG data (prior to the assertion) */
@@ -543,10 +547,6 @@ void up_assert(const char *filename, int lineno)
   /* Flush any buffered SYSLOG data (from the above) */
 
   syslog_flush();
-
-#ifdef CONFIG_BOARD_CRASHDUMP
-  board_crashdump(up_getsp(), running_task(), filename, lineno);
-#endif
 
   arm_assert();
 }


### PR DESCRIPTION
## Summary

## Impact

## Testing

