### PR TITLE
arch/arm/armv7-m: imlement dcache clean as barrier in write-through mode

### DIFF
--- a/arch/arm/src/armv7-m/arm_cache.c
+++ b/arch/arm/src/armv7-m/arm_cache.c
@@ -574,10 +574,10 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
       start += ssize;
     }
   while (start < end);
+#endif /* !CONFIG_ARMV7M_DCACHE_WRITETHROUGH */
 
   ARM_DSB();
   ARM_ISB();
-#endif /* !CONFIG_ARMV7M_DCACHE_WRITETHROUGH */
 }
 #endif /* CONFIG_ARMV7M_DCACHE */
 
@@ -651,10 +651,10 @@ void up_clean_dcache_all(void)
       while (tmpways--);
     }
   while (sets--);
+#endif /* !CONFIG_ARMV7M_DCACHE_WRITETHROUGH */
 
   ARM_DSB();
   ARM_ISB();
-#endif /* !CONFIG_ARMV7M_DCACHE_WRITETHROUGH */
 }
 #endif /* CONFIG_ARMV7M_DCACHE */
 

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -1408,13 +1408,6 @@ static int sam_transmit(struct sam_emac_s *priv, int qid)
   regval |= EMAC_NCR_TSTART;
   sam_putreg(priv, SAM_EMAC_NCR_OFFSET, regval);
 
-  /* REVISIT: Sometimes TSTART is missed?  In this case, the symptom is
-   * that the packet is not sent until the next transfer when TXSTART
-   * is set again.
-   */
-
-  sam_putreg(priv, SAM_EMAC_NCR_OFFSET, regval);
-
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, SAM_TXTIMEOUT,


### PR DESCRIPTION
## Summary
Fix GMAC packet transmission does not start sometimes

## Impact
Improve Ethernet performance of SAMv7

## Testing

